### PR TITLE
Rename of PARSE_GROBID Standardaction

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -480,7 +480,7 @@ public class JabRefFrame extends BorderPane {
         HBox rightSide = new HBox(
                 factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(this, StandardEntryType.Article, dialogService, Globals.prefs, stateManager)),
                 factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(this, dialogService, Globals.prefs, stateManager)),
-                factory.createIconButton(StandardActions.PARSE_GROBID, new ExtractBibtexAction(stateManager)),
+                factory.createIconButton(StandardActions.NEW_ENTRY_FROM_PLAINTEX, new ExtractBibtexAction(stateManager)),
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
                 new Separator(Orientation.VERTICAL),
                 factory.createIconButton(StandardActions.UNDO, new OldDatabaseCommandWrapper(Actions.UNDO, this, stateManager)),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -120,9 +120,8 @@ public enum StandardActions implements Action {
     SELECT_ALL(Localization.lang("Select all"), KeyBinding.SELECT_ALL),
 
     NEW_ENTRY(Localization.lang("New entry"), IconTheme.JabRefIcons.ADD_ENTRY, KeyBinding.NEW_ENTRY),
-    PARSE_GROBID(Localization.lang("Parse with Grobid"), JabRefIcons.GROBID_PARSE),
     NEW_ARTICLE(Localization.lang("New article"), IconTheme.JabRefIcons.ADD_ARTICLE),
-    NEW_ENTRY_FROM_PLAINTEX(Localization.lang("New entry from plain text"), KeyBinding.NEW_FROM_PLAIN_TEXT),
+    NEW_ENTRY_FROM_PLAINTEX(Localization.lang("New entry from plain text"), JabRefIcons.NEW_ENTRY_FROM_PLAINTEX),
     LIBRARY_PROPERTIES(Localization.lang("Library properties")),
     EDIT_PREAMBLE(Localization.lang("Edit preamble")),
     EDIT_STRINGS(Localization.lang("Edit string constants"), IconTheme.JabRefIcons.EDIT_STRINGS, KeyBinding.EDIT_STRINGS),

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -299,7 +299,7 @@ public class IconTheme {
         REMOVE_ABBREVIATION_LIST(MaterialDesignIcon.FOLDER_REMOVE),
         ADD_ABBREVIATION(MaterialDesignIcon.PLAYLIST_PLUS),
         REMOVE_ABBREVIATION(MaterialDesignIcon.PLAYLIST_MINUS),
-        GROBID_PARSE(MaterialDesignIcon.PLUS_BOX);
+        NEW_ENTRY_FROM_PLAINTEX(MaterialDesignIcon.PLUS_BOX);
 
         private final JabRefIcon icon;
 


### PR DESCRIPTION
According to the suggestion of Tobias Diez i changed in the JabrefFrame class the PARSE_GROBID Standardaction to NEW_ENTRY_FROM_PLAINTEX.